### PR TITLE
chore(JF-390): add container image scan non-breaking

### DIFF
--- a/.github/workflows/jf_worker-cd.yml
+++ b/.github/workflows/jf_worker-cd.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    timeout-minutes: 5
+    timeout-minutes: 15
     env:
       # This will suppress any download for dependencies and plugins or upload messages which would clutter the console log.
       # `showDateTime` will show the passed time in milliseconds. You need to specify `--batch-mode` to make this work.

--- a/.github/workflows/jf_worker-ci.yml
+++ b/.github/workflows/jf_worker-ci.yml
@@ -100,6 +100,12 @@ jobs:
           fail_if_no_tests: true
 
       ## run in case 3.
+      - name: Get allowed-list
+        run: |
+          if [ ! -f .github/containerscan/allowedlist.yaml ]; then
+              echo "create allowedlist.yaml from secret" ;
+              echo "${{ secrets.CONTAINERSCAN_ALLOWED_LIST }}" > .github/containerscan/allowedlist.yaml ;
+          fi
       - name: Scan container image
         if: ${{ inputs.skipTests == false && inputs.scanImage == true }}
         uses: azure/container-scan@f9af925b897d8af5f7e0026b8bca9346261abc93
@@ -113,7 +119,8 @@ jobs:
       - name: Perform sonar analysis
         if: inputs.sonarAnalysisEnabled
         continue-on-error: true
-        run: mvn $MAVEN_CLI_OPTS sonar:sonar -Dsonar.scm.disabled=true -Dsonar.qualitygate.wait=true
+        run: |
+          mvn $MAVEN_CLI_OPTS sonar:sonar -Dsonar.scm.disabled=true -Dsonar.qualitygate.wait=true -Dsonar.dependencyCheck.htmlReportPath=target/dependency-check-report.html
 
       - name: Notify Mattermost
         uses: hennejg/slack-build-notifier@v1.1

--- a/.github/workflows/jf_worker-ci.yml
+++ b/.github/workflows/jf_worker-ci.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     env:
       # This will suppress any download for dependencies and plugins or upload messages which would clutter the console log.
       # `showDateTime` will show the passed time in milliseconds. You need to specify `--batch-mode` to make this work.

--- a/.github/workflows/jf_worker-ci.yml
+++ b/.github/workflows/jf_worker-ci.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: boolean
         default: false
+      scanImage:
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -49,7 +53,7 @@ jobs:
 
       - name: Prepare maven settings
         env:
-          REGISTRY_URL: ${{ secrets.LEVIGO_NEXUS_REGISTRY_SNAPSHOTS }}
+          REGISTRY_URL: ${{ secrets.LEVIGO_NEXUS_REGISTRY_RELEASES }}
           REPOSITORY_URL: ${{ secrets.LEVIGO_NEXUS_REPO_ALL }}
           REPOSITORY_USERID: ${{ secrets.LEVIGO_NEXUS_USERNAME }}
           REPOSITORY_CREDENTIALS: ${{ secrets.LEVIGO_NEXUS_PASSWORD }}
@@ -63,6 +67,26 @@ jobs:
       - name: Perform build
         if: inputs.skipTests == false
         run: mvn $MAVEN_CLI_OPTS verify -Dmaven.test.failure.ignore=true
+
+      ## Build and Test + Scan
+      - name: Perform build
+        if: ${{ inputs.skipTests == false && inputs.scanImage == true }}
+        env:
+          REGISTRY_URL: ${{ secrets.LEVIGO_NEXUS_REGISTRY_RELEASES }}
+        run: |
+          mvn $MAVEN_CLI_OPTS verify \
+            -Dmaven.test.failure.ignore=true \
+            -DenableDocker \
+            -Ddocker.registry.from=${REGISTRY_URL} \
+            -Djib-maven-plugin.goal=dockerBuild
+          echo "CONTAINER_IMAGE=$(jq -r .image target/jib-image.json)" >> $GITHUB_ENV
+
+      - name: Scan container image
+        continue-on-error: true
+        if: ${{ inputs.skipTests == false && inputs.scanImage == true }}
+        uses: azure/container-scan@f9af925b897d8af5f7e0026b8bca9346261abc93
+        with:
+          image-name: ${{ env.CONTAINER_IMAGE }}
 
       - name: Publish Test Report
         if: inputs.skipTests == false

--- a/.github/workflows/jf_worker-ci.yml
+++ b/.github/workflows/jf_worker-ci.yml
@@ -26,7 +26,7 @@ on:
       scanImage:
         required: false
         type: boolean
-        default: false
+        default: true
 
 jobs:
   build:
@@ -63,12 +63,21 @@ jobs:
           mkdir -p ~/.m2
           envsubst < ./.github/settings.xml > ~/.m2/settings.xml
 
-      ## Build and Test
+      ##
+      ## Starting here, there are 3 branches in the workflow
+      ##
+
+      ## 1. Build without running Tests
       - name: Perform build
-        if: inputs.skipTests == false
+        if: inputs.skipTests
+        run: mvn $MAVEN_CLI_OPTS verify -DskipTests
+
+      ## 2. Build and Test
+      - name: Perform build
+        if: ${{ inputs.skipTests == false && inputs.scanImage == false }}
         run: mvn $MAVEN_CLI_OPTS verify -Dmaven.test.failure.ignore=true
 
-      ## Build and Test + Scan
+      ## 3. Build and Test + Build Image (default)
       - name: Perform build
         if: ${{ inputs.skipTests == false && inputs.scanImage == true }}
         env:
@@ -81,13 +90,7 @@ jobs:
             -Djib-maven-plugin.goal=dockerBuild
           echo "CONTAINER_IMAGE=$(jq -r .image target/jib-image.json)" >> $GITHUB_ENV
 
-      - name: Scan container image
-        continue-on-error: true
-        if: ${{ inputs.skipTests == false && inputs.scanImage == true }}
-        uses: azure/container-scan@f9af925b897d8af5f7e0026b8bca9346261abc93
-        with:
-          image-name: ${{ env.CONTAINER_IMAGE }}
-
+      ## run in case 2. and 3.
       - name: Publish Test Report
         if: inputs.skipTests == false
         uses: scacap/action-surefire-report@v1
@@ -96,12 +99,17 @@ jobs:
           fail_on_test_failures: true
           fail_if_no_tests: true
 
-      ## Build without running Tests
-      - name: Perform build
-        if: inputs.skipTests
-        run: mvn $MAVEN_CLI_OPTS verify -DskipTests
+      ## run in case 3.
+      - name: Scan container image
+        if: ${{ inputs.skipTests == false && inputs.scanImage == true }}
+        uses: azure/container-scan@f9af925b897d8af5f7e0026b8bca9346261abc93
+        with:
+          image-name: ${{ env.CONTAINER_IMAGE }}
 
-      ## Static code analysis with sonarqube
+      ##
+      ## End of branches
+      ##
+
       - name: Perform sonar analysis
         if: inputs.sonarAnalysisEnabled
         continue-on-error: true


### PR DESCRIPTION
- Build and scan container image by default. 
- Fail the build if _critical_ or _high_ severity vulnerabilities are discovered.
- Upload dependency-check report to SonarQube, if there is one at `target/dependency-check-report.html`

After merging, this version of the reusable workflow shall be tagged with 'latest' and jf-workers are migrated to it one by one.